### PR TITLE
add tests form SkipModal.tsx component

### DIFF
--- a/.github/workflows/lint-test-coverage.yml
+++ b/.github/workflows/lint-test-coverage.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -27,7 +27,7 @@ vi.stubGlobal(
 			ok: true,
 			json: () => Promise.resolve(mockFetchResponse),
 		})
-	) as any
+	) as unknown as typeof fetch
 );
 
 describe("App", () => {

--- a/src/__tests__/SkipModal.test.tsx
+++ b/src/__tests__/SkipModal.test.tsx
@@ -25,7 +25,7 @@ describe("SkipModal", () => {
 		render(<SkipModal isOpen={true} skip={mockSkip} onClose={() => {}} />);
 
 		expect(screen.getByText(/8-yard skip/i)).toBeInTheDocument();
-		expect(screen.getByText(/Postcode: NR32/i)).toBeInTheDocument();
+		expect(screen.getByText(/NR32/i)).toBeInTheDocument();
 		expect(
 			screen.getByRole("button", { name: /Continue/i })
 		).toBeInTheDocument();

--- a/src/__tests__/SkipModal.test.tsx
+++ b/src/__tests__/SkipModal.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import type { SkipOption } from "../types/SkipOption";
+import SkipModal from "../components/SkipModal";
+
+const mockSkip: SkipOption = {
+	size: 8,
+	hirePeriod: 14,
+	transportCost: null,
+	perTonneCost: null,
+	priceB4VAT: 375,
+	vat: 20,
+	postCode: "NR32",
+	area: "Lowestoft",
+	forbidden: false,
+	createdAt: "2025-04-03T13:51:46.897146",
+	updatedAt: "2025-04-07T13:16:53.171",
+	allowedOnRoad: true,
+	allowsHeavyWaste: true,
+	imageUrl:
+		"https://yozbrydxdlcxghkphhtq.supabase.co/storage/v1/object/public/skips/skip-sizes/5-yarder-skip.jpg",
+};
+
+describe("SkipModal", () => {
+	it("render modal with skip details when open", () => {
+		render(<SkipModal isOpen={true} skip={mockSkip} onClose={() => {}} />);
+
+		expect(screen.getByText(/8-yard skip/i)).toBeInTheDocument();
+		expect(screen.getByText(/Postcode: NR32/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /Continue/i })
+		).toBeInTheDocument();
+	});
+
+	it("does not render modal content when closed", () => {
+		render(<SkipModal isOpen={false} skip={mockSkip} onClose={() => {}} />);
+		expect(screen.queryByText(/8-yard skip/i)).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
SkipModal tests for
- when skip selected, modal renders with skip details
- when closed, no skip details should be on the screen